### PR TITLE
Fix connector tryCatchWrapper definition

### DIFF
--- a/vaadin-select-flow/src/main/resources/META-INF/resources/frontend/selectConnector.js
+++ b/vaadin-select-flow/src/main/resources/META-INF/resources/frontend/selectConnector.js
@@ -1,6 +1,8 @@
 (function () {
     const tryCatchWrapper = function (callback) {
-        return window.Vaadin.Flow.tryCatchWrapper(callback, 'Vaadin Select', 'vaadin-select-flow');
+        return (...args) => {
+            return window.Vaadin.Flow.tryCatchWrapper(callback, 'Vaadin Select', 'vaadin-select-flow')(...args);
+        };
     };
 
     window.Vaadin.Flow.selectConnector = {


### PR DESCRIPTION
Connected to https://github.com/vaadin/vaadin-combo-box-flow/issues/313
Make the `Flow.tryCatchWrapper` called lazily.