### PR TITLE
Make select component implement HasTheme interface

### DIFF
--- a/vaadin-select-flow-demo/src/main/java/com/vaadin/flow/component/select/SelectView.java
+++ b/vaadin-select-flow-demo/src/main/java/com/vaadin/flow/component/select/SelectView.java
@@ -262,12 +262,12 @@ public class SelectView extends DemoView {
         Select<String> centerSelect = new Select<>();
         centerSelect.setItems("Left", "Center", "Right");
         centerSelect.setValue("Center");
-        centerSelect.getElement().setAttribute("theme", "align-center");
+        centerSelect.setThemeName("align-center");
 
         Select<String> rightSelect = new Select<>();
         rightSelect.setItems("Left", "Center", "Right");
         rightSelect.setValue("Right");
-        rightSelect.getElement().setAttribute("theme", "align-right");
+        rightSelect.setThemeName("align-right");
         // end-source-example
         div.add(leftSelect, centerSelect, rightSelect);
         leftSelect.getStyle().set("margin-right", "5px");

--- a/vaadin-select-flow-integration-tests/src/main/java/com/vaadin/flow/component/select/examples/TestView.java
+++ b/vaadin-select-flow-integration-tests/src/main/java/com/vaadin/flow/component/select/examples/TestView.java
@@ -27,6 +27,7 @@ public class TestView extends Div implements HasUrlParameter<String> {
     public static final String SELECT_LAST_ITEM = "Select last item";
     public static final String ITEMS_PARAM = "items=";
     public static final String SELECT_PARAM = "select=";
+    public static final String THEME_PARAM="theme";
     private int valueChangeCounter = 0;
     private int itemCounter = 0;
 
@@ -45,7 +46,6 @@ public class TestView extends Div implements HasUrlParameter<String> {
 
     public TestView() {
         select = new Select<>();
-
         createOptions();
 
         valueChangeContainer = new Div();
@@ -258,6 +258,9 @@ public class TestView extends Div implements HasUrlParameter<String> {
                     parameter.replace("emptyselectioncaption=", ""));
         } else if (parameter.contains("autofocus")) {
             select.setAutofocus(true);
+        }else if(parameter.contains(THEME_PARAM)){
+            select.setThemeName("align-center");
+            setItems(5);
         }
 
         if (parameter.contains("disabled")) {

--- a/vaadin-select-flow-integration-tests/src/test/java/com/vaadin/flow/component/select/test/AbstractSelectIT.java
+++ b/vaadin-select-flow-integration-tests/src/test/java/com/vaadin/flow/component/select/test/AbstractSelectIT.java
@@ -230,6 +230,13 @@ public abstract class AbstractSelectIT extends AbstractComponentIT {
             Assert.assertEquals("invalid text", emptySelectionItemCaption,
                     itemElement.getText());
         }
+
+        public void themeNamePresent(String themeName){
+            Assert.assertTrue("theme attribute missing",
+                    selectElement.hasAttribute("theme"));
+            Assert.assertTrue("theme property has wrong value",
+                    themeName.equals(selectElement.getPropertyString("theme")));
+        }
     }
 
     protected final Page page = new Page();

--- a/vaadin-select-flow-integration-tests/src/test/java/com/vaadin/flow/component/select/test/BasicFeaturesIT.java
+++ b/vaadin-select-flow-integration-tests/src/test/java/com/vaadin/flow/component/select/test/BasicFeaturesIT.java
@@ -92,6 +92,12 @@ public class BasicFeaturesIT extends AbstractSelectIT {
         verify.selectedItem("Item-0");
     }
 
+    @Test
+    public void testThemeNamePresent(){
+        open("theme");
+        verify.themeNamePresent("align-center");
+    }
+
     @Override
     protected int getInitialNumberOfItems() {
         return 5;

--- a/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
+++ b/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/Select.java
@@ -25,6 +25,7 @@ import com.vaadin.flow.component.AttachEvent;
 import com.vaadin.flow.component.Component;
 import com.vaadin.flow.component.HasComponents;
 import com.vaadin.flow.component.HasSize;
+import com.vaadin.flow.component.HasTheme;
 import com.vaadin.flow.component.HasValidation;
 import com.vaadin.flow.component.ItemLabelGenerator;
 import com.vaadin.flow.component.Tag;
@@ -63,7 +64,7 @@ import com.vaadin.flow.shared.Registration;
 @JsModule("./selectConnector.js")
 public class Select<T> extends GeneratedVaadinSelect<Select<T>, T>
         implements HasDataProvider<T>, HasItemsAndComponents<T>, HasSize,
-        HasValidation, SingleSelect<Select<T>, T> {
+        HasValidation, HasTheme, SingleSelect<Select<T>, T> {
 
     public static final String LABEL_ATTRIBUTE = "label";
 


### PR DESCRIPTION
Implementing the interface provides convenient methods to set the theme.

Instead of using `getElement().setAttribute("theme","value")`, a `setThemeName("value")` can be called directly

Related to #22 