### PR TITLE
Fix selectConnector export for OSGi

### DIFF
--- a/vaadin-select-flow/pom.xml
+++ b/vaadin-select-flow/pom.xml
@@ -42,6 +42,27 @@
             <scope>provided</scope>
         </dependency>
 
+        <dependency>
+            <groupId>com.vaadin</groupId>
+            <artifactId>flow-osgi</artifactId>
+            <version>${flow.version}</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>osgi.cmpn</artifactId>
+            <version>6.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>org.osgi</groupId>
+            <artifactId>org.osgi.core</artifactId>
+            <version>6.0.0</version>
+            <scope>provided</scope>
+        </dependency>
+
         <!--Webjar-->
         <dependency>
             <groupId>org.webjars.bowergithub.vaadin</groupId>

--- a/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/osgi/SelectConnectorResource.java
+++ b/vaadin-select-flow/src/main/java/com/vaadin/flow/component/select/osgi/SelectConnectorResource.java
@@ -1,0 +1,20 @@
+package com.vaadin.flow.component.select.osgi;
+
+
+import com.vaadin.flow.osgi.support.OsgiVaadinStaticResource;
+import org.osgi.service.component.annotations.Component;
+
+import java.io.Serializable;
+
+@Component(immediate = true, service = OsgiVaadinStaticResource.class)
+public class SelectConnectorResource implements OsgiVaadinStaticResource, Serializable {
+    @Override
+    public String getPath() {
+        return "/META-INF/resources/frontend/selectConnector.js";
+    }
+
+    @Override
+    public String getAlias() {
+        return "/frontend/selectConnector.js";
+    }
+}


### PR DESCRIPTION
When using Select in an OSGi app, it throws `TypeError: Cannot read property 'initLazy' of undefined`.
This fix adds an OSGiStaticVaadinResource to export selectConnector.js.